### PR TITLE
Fix plotProfiles to support CompressedRleList (Bioconductor >= 3.16)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tsTools
 Type: Package
 Title: Toolbox for Functional Genomics Data Processing in R
-Version: 0.2.0
+Version: 0.2.1
 Author: Tobias Straub
 Maintainer: Tobias Straub <tobias.straub@lmu.de>
 Description: R Toolbox for ChIPseq, MNaseSeq, RNASeq and alike

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,5 @@
+# tsTools 0.2.1
+
+## Bug fixes
+
+- `plotProfiles()`: broadened RleList type check from `inherits(x, "SimpleRleList")` to `is(x, "RleList")` to support both `SimpleRleList` and `CompressedRleList`. In Bioconductor >= 3.16 (IRanges >= 2.30), `coverage()`, `RleList()`, and RleList arithmetic return `CompressedRleList` objects; the old guard silently skipped these tracks, producing blank panels with no error or warning.

--- a/R/browser.R
+++ b/R/browser.R
@@ -11,7 +11,7 @@
 #' @param fstart Deprecated. Start of the genomic window (bp). Use \code{ranges} instead.
 #' @param fend Deprecated. End of the genomic window (bp). Use \code{ranges} instead.
 #' @param fchr Deprecated. Chromosome of the genomic window. Use \code{ranges} instead.
-#' @param profs Named list of coverages to be plotted (SimpleRleList objects).
+#' @param profs Named list of coverages to be plotted (RleList objects, including SimpleRleList and CompressedRleList).
 #' @param cols Colors of the profiles.
 #' @param ann A named list of annotation dataframes. Each dataframe should have
 #'   columns: chr, start, end, col (optional), label (optional).
@@ -297,7 +297,7 @@ plotProfiles <- function(ranges = NULL, fstart = NULL, fend = NULL, fchr = NULL,
     }
 
     for (i in 1:length(profs)) {
-      if (inherits(profs[[i]], "SimpleRleList")) {
+      if (is(profs[[i]], "RleList")) {
         xl <- c(fstart, seq(fstart, fend, length.out = vsize), fend)
         yl <- c(0, HilbertVis::shrinkVector(
           as.vector(profs[[i]][[fchr]])[fstart:fend], newLength = vsize), 0)


### PR DESCRIPTION
## Summary

- **Bug:** `plotProfiles()` silently skipped coverage tracks for any `CompressedRleList` object, producing blank panels with no error or warning.
- **Root cause:** The type guard `inherits(profs[[i]], "SimpleRleList")` in `plot.profiles` only matches `SimpleRleList`. In Bioconductor >= 3.16 (IRanges >= 2.30), `coverage()`, `RleList()`, and RleList arithmetic return `CompressedRleList` objects instead.
- **Fix:** Replace with `is(profs[[i]], "RleList")`, which is `TRUE` for both `SimpleRleList` and `CompressedRleList` via their shared virtual parent class in IRanges. The data-access line `as.vector(profs[[i]][[fchr]])[fstart:fend]` works correctly for both classes — only the guard needed updating.

## Verification

```r
library(IRanges)
x <- RleList(IV = Rle(c(rep(0, 1000), rep(5, 500), rep(0, 1000))))
cat(class(x), "\n")               # CompressedRleList in modern BioC
cat(is(x, "RleList"), "\n")      # TRUE  — passes fixed guard
cat(inherits(x, "SimpleRleList"), "\n")  # FALSE — failed old guard
```

## Changes

- `R/browser.R`: `inherits(x, "SimpleRleList")` → `is(x, "RleList")`; updated `@param profs` roxygen doc
- `DESCRIPTION`: version bump 0.2.0 → 0.2.1
- `NEWS.md`: created with changelog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)